### PR TITLE
Make endnotes consistent with scans

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -13,34 +13,34 @@
 					<p>“Nothing so forms a young man as an intimacy with a woman of good breeding.” <a href="chapter-2.xhtml#noteref-1" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-2" epub:type="endnote">
-					<p>He was in fact 27 at the time. (Translator’s note.) <a href="chapter-2.xhtml#noteref-2" epub:type="backlink">↩</a></p>
+					<p>Tolstoy makes a slip here: he was twenty-seven. <a href="chapter-2.xhtml#noteref-2" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-3" epub:type="endnote">
-					<p>Russians generally make a distinction between Europeans and Russians. (Translator’s note.) <a href="chapter-3.xhtml#noteref-3" epub:type="backlink">↩</a></p>
+					<p>Russians generally make a distinction between Europeans and Russians. <a href="chapter-3.xhtml#noteref-3" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-4" epub:type="endnote">
-					<p>To keep peace between peasants and owners. (Translator’s note.) <a href="chapter-3.xhtml#noteref-4" epub:type="backlink">↩</a></p>
+					<p>To keep peace between peasants and owners. <a href="chapter-3.xhtml#noteref-4" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-5" epub:type="endnote">
-					<p>A fermented drink prepared from mare’s milk. (Translator’s note.) <a href="chapter-3.xhtml#noteref-5" epub:type="backlink">↩</a></p>
+					<p>A fermented drink prepared from mare’s milk. <a href="chapter-3.xhtml#noteref-5" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-6" epub:type="endnote">
-					<p>The <i xml:lang="ru-Latn">desyatina</i> is about 2.75 acres. (Translator’s note.) <a href="chapter-3.xhtml#noteref-6" epub:type="backlink">↩</a></p>
+					<p>The <i xml:lang="ru-Latn">desyatina</i> is about 2¾ acres. <a href="chapter-3.xhtml#noteref-6" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-7" epub:type="endnote">
-					<p>Tolstoy’s version differs slightly in a few places from our own Authorized or Revised version. I have followed his text, for in a letter to Fet, quoted on <abbr>p.</abbr> 18, <abbr>vol.</abbr> <span epub:type="z3998:roman">II</span>, of my <i epub:type="se:name.publication.book">Life of Tolstoy</i>, he says that “The Authorized English version [of Ecclesiastes] is bad.” (Translator’s note.) <a href="chapter-6.xhtml#noteref-7" epub:type="backlink">↩</a></p>
+					<p>Tolstoy’s version differs slightly in a few places from our own Authorized or Revised version. I have followed his text, for in a letter to Fet, quoted on <abbr>p.</abbr> 11, <abbr>vol.</abbr> <span epub:type="z3998:roman">II</span>, of my <i epub:type="se:name.publication.book">Life of Tolstoy</i>, he says that “The Authorized English version [of Ecclesiastes] is bad.” <a href="chapter-6.xhtml#noteref-7" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-8" epub:type="endnote">
-					<p>This passage is noteworthy as being one of the few references made by Tolstoy at this period to the revolutionary or “Back-to-the-People” movement, in which many young men and women were risking and sacrificing home, property, and life itself from motives which had much in common with his own perception that the upper layers of Society are parasitic and prey on the vitals of the people who support them. (Translator’s note.) <a href="chapter-10.xhtml#noteref-8" epub:type="backlink">↩</a></p>
+					<p>This passage is noteworthy as being one of the few references made by Tolstoy at this period to the revolutionary or “Back-to-the-People” movement, in which many young men and women were risking and sacrificing home, property, and life itself from motives which had much in common with his own perception that the upper layers of Society are parasitic and prey on the vitals of the people who support them. <a href="chapter-10.xhtml#noteref-8" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-9" epub:type="endnote">
-					<p>In Russia Sunday was called Resurrection-day. (Translator’s note.) <a href="chapter-14.xhtml#noteref-9" epub:type="backlink">↩</a></p>
+					<p>In Russia Sunday was called Resurrection-day. <a href="chapter-14.xhtml#noteref-9" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-10" epub:type="endnote">
-					<p>A sect that rejects sacraments and ritual. (Translator’s note.) <a href="chapter-15.xhtml#noteref-10" epub:type="backlink">↩</a></p>
+					<p>A sect that rejects sacraments and ritual. <a href="chapter-15.xhtml#noteref-10" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-11" epub:type="endnote">
-					<p>At the time this was written capital punishment was considered to be abolished in Russia. (Translator’s note.) <a href="chapter-15.xhtml#noteref-11" epub:type="backlink">↩</a></p>
+					<p>At the time this was written, capital punishment was considered to be abolished in Russia. <a href="chapter-15.xhtml#noteref-11" epub:type="backlink">↩</a></p>
 				</li>
 			</ol>
 		</section>


### PR DESCRIPTION
First I removed the `(Translator’s note.)` citations, since this is not part of the text and seems pointless when every endnote seems to be by Aylmer Maude. I also made some of the endnotes consistent with what was in the scans:

note-2: https://babel.hathitrust.org/cgi/pt?id=njp.32101068609633&view=2up&seq=24&skin=2021
note-6: https://babel.hathitrust.org/cgi/pt?id=njp.32101068609633&view=2up&seq=34&skin=2021
note-7: https://babel.hathitrust.org/cgi/pt?id=njp.32101068609633&view=2up&seq=58&skin=2021
note-11: https://babel.hathitrust.org/cgi/pt?id=njp.32101068609633&view=2up&seq=108&skin=2021