### PR TITLE
Fix Wikipedia link

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -49,7 +49,7 @@
 		<dc:source>https://catalog.hathitrust.org/Record/008973972</dc:source>
 		<meta property="se:word-count">25993</meta>
 		<meta property="se:reading-ease.flesch">63.22</meta>
-		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/A_Confession</meta>
+		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Confession_(Leo_Tolstoy)</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/leo-tolstoy_a-confession_aylmer-maude</meta>
 		<dc:creator id="author">Leo Tolstoy</dc:creator>
 		<meta property="file-as" refines="#author">Tolstoy, Leo</meta>


### PR DESCRIPTION
The previous Wikipedia link worked, but through an automatic redirect.